### PR TITLE
Fix quoting in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,10 @@ Individual field
 
 {{ form.\|materializecss }}
 
-Custom size (default is ‘s12’)
+Custom size (default is 's12')
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{{ form\|materializecss:‘m6’ }}
+{{ form\|materializecss:'m6' }}
 
 Demo
 ----


### PR DESCRIPTION
Non-ASCII characters in README.rst make the code incorrect but also break package installation on Windows (`setup.py` opens this file for reading but does not specify a proper encoding).
