### PR TITLE
Fix template loading when installed with easy_install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,6 @@ setup(
     ],
  
     license="MIT",
+
+    zip_safe=False
 )


### PR DESCRIPTION
If you install a package using `easy_install` or `setup.py install`, it will default to installing as a zipped egg. Django is by default unable to find templates inside zipped archives and even with an egg template loader enabled it's very slow as it involves unpacking the archive when the template is needed.

Setting `zip_safe=False` forces `setuptools` to always install the package uncompressed.
