### PR TITLE
Django 1.11 compatibility

### DIFF
--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.template import Context
 from django.template.loader import get_template
 from django import template
 
@@ -33,7 +32,7 @@ def render(element, markup_classes):
     if element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("materializecssform/field.html")
-        context = Context({'field': element, 'classes': markup_classes})
+        context = {'field': element, 'classes': markup_classes}
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -42,13 +41,13 @@ def render(element, markup_classes):
                     add_input_classes(field)
 
             template = get_template("materializecssform/formset.html")
-            context = Context({'formset': element, 'classes': markup_classes})
+            context = {'formset': element, 'classes': markup_classes}
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
             template = get_template("materializecssform/form.html")
-            context = Context({'form': element, 'classes': markup_classes})
+            context = {'form': element, 'classes': markup_classes}
 
     return template.render(context)
 


### PR DESCRIPTION
Source: https://docs.djangoproject.com/en/dev/releases/1.11/#django-template-render-prohibits-non-dict-context

@florent1933 please release new version with this fix.