### PR TITLE
Replace Context to dict for Django 2.0.4 compatibility

### DIFF
--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -34,7 +34,7 @@ def render(element, markup_classes):
     if element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("materializecssform/field.html")
-        context = Context({'field': element, 'classes': markup_classes})
+        context = {'field': element, 'classes': markup_classes}
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -43,13 +43,13 @@ def render(element, markup_classes):
                     add_input_classes(field)
 
             template = get_template("materializecssform/formset.html")
-            context = Context({'formset': element, 'classes': markup_classes})
+            context = {'formset': element, 'classes': markup_classes}
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
             template = get_template("materializecssform/form.html")
-            context = Context({'form': element, 'classes': markup_classes})
+            context = {'form': element, 'classes': markup_classes}
 
     return template.render(context)
 


### PR DESCRIPTION
This change fixes the following error : context must be a dict rather than RequestContext
