### PR TITLE
Update 2 occurrences of field.name to field.html_name

### DIFF
--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -73,7 +73,7 @@
                 {% if classes.icon %}
                     <i class="material-icons prefix">{{ classes.icon }}</i>
                 {% endif %}
-                <select multiple name="{{ field.name }}">
+                <select multiple name="{{ field.html_name }}">
                     {% for choice in field %}
                           {{ choice.tag }}
                     {% endfor %}
@@ -96,7 +96,7 @@
                 {% if classes.icon %}
                     <i class="material-icons prefix">{{ classes.icon }}</i>
                 {% endif %}
-                <select name="{{ field.name }}">
+                <select name="{{ field.html_name }}">
                     {% for choice in field %}
                           {{ choice.tag }}
                     {% endfor %}


### PR DESCRIPTION
This fixes an issue when using multiple forms with Django form prefixes. The rest of the fields already use field.html_name which takes into account Django form prefixes versus field.name which does not.

https://docs.djangoproject.com/en/2.1/ref/forms/api/#attributes-of-boundfield
https://docs.djangoproject.com/en/2.1/ref/forms/api/#prefixes-for-forms