### PR TITLE
turn off localization just when filling out value of datefield

### DIFF
--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -1,4 +1,5 @@
 {% load materializecss %}
+{% load l10n %}
 
 
     {% if field|is_checkbox %}
@@ -53,7 +54,7 @@
             <i class="material-icons prefix">{{ classes.icon }}</i>
         {% endif %}
 
-        <input type="date" id="{{ field.auto_id }}" name="{{ field.html_name }}" class="datepicker" value="{% if field.value %}{{ field.value }}{% endif %}" {% include 'materializecssform/attrs.html' %} >
+        <input type="date" id="{{ field.auto_id }}" name="{{ field.html_name }}" class="datepicker" value="{% if field.value %}{% localize off %}{{ field.value }}{% endlocalize %}{% endif %}" {% include 'materializecssform/attrs.html' %} >
         <label for="{{ field.id_for_label }}">{{ field.label }}</label>
 
         {% for error in field.errors %}


### PR DESCRIPTION
When using this form will fields pre-filled in... i.e. as an edit/update form.... then django sets the "value" of the date field to a localized value, which then does not work with the datepicker.  So I changed the template to turn it off only when it is setting the value parameter or whatever it is called... see the changed lines where localize off was tagged in.