### PR TITLE
Fixed typo in class assignment for textarea

### DIFF
--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -174,7 +174,7 @@
     </div>
 
     {% elif field|is_textarea %}
-        <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }">
+        <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
             {% if classes.icon %}
                 <i class="material-icons prefix">{{ classes.icon }}</i>
             {% endif %}


### PR DESCRIPTION
A typo in Django syntax made the assignment of single value class impossible for <textarea>.