### PR TITLE
Fix issue during package install when locale is set to C/ASCII

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 import materializecssform
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
Hi!

First, thanks for the very cool package!

**Issue**
I have been trying to install it in a Docker environment (Ubuntu 18:04) using pip. However, there is a decoding error when running the install (very likely due to the 'é' character in the README.md) :
```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-p38l1d_u/django-materializecss-form/setup.py", line 9, in <module>
        long_description = fh.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3278: ordinal not in range(128)
```

I have been trying to set LC_ALL and PYTHONIOENCODING to UTF-8, but it does not seem work.

**Solution**
This pull request is an attempt to solve the problem by specifying the encoding explicitly. It is only compatible with python 3 (I didn't see evidence of python 2 compatibility in the package). 

If necessary, I there is another option which could be used in python2:
```python3
with open("filename.txt", "rb") as f:
    contents = f.read().decode("UTF-8")
```

Thanks for reading!