### PR TITLE
Support for optional icon sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ This is most useful for adding a descriptive icon when you are creating a custom
 {{ form.FIELD_NAME|materializecss:'custom_size=s12 m6, icon=person' }}
 ```
 
+#### Opional icon sets
+If you're using optional icon sets you need to set `MATERIALIZECSS_ICON_SET` in your settings file:
+
+```python
+MATERIALIZECSS_ICON_SET = 'fontawesome'
+```
+Currently [Font Awesome](https://www.fontawesome.com/) and [GLYPHICONS](https://www.glyphicons.com) is supported, however you might need to modify your CSS for full support.
+
 ### Note about `DateTimeField`
 Input field is rendered as a *datetime-local* type, this lets the user easily enter both a date and a time. As this field requires ISO-8601 format, your main project settings need to include the ISO format in order for the form to interpret this field valid:
 ```

--- a/materializecssform/config.py
+++ b/materializecssform/config.py
@@ -2,3 +2,4 @@ from django.conf import settings
 
 MATERIALIZECSS_COLUMN_COUNT = getattr(settings, 'MATERIALIZECSS_COLUMN_COUNT', 12)
 MATERIALIZECSS_VALIDATION = getattr(settings, 'MATERIALIZECSS_VALIDATION', True)
+MATERIALIZECSS_ICON_SET = getattr(settings, 'MATERIALIZECSS_ICON_SET', 'default')

--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -6,7 +6,7 @@
     <div class="col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
         <div class="{% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}">
             {% if classes.icon %}
-                <i class="material-icons prefix">{{ classes.icon }}</i>
+                {% include 'materializecssform/field_icon.html' %}
             {% endif %}
             <label>
 
@@ -30,7 +30,7 @@
     <div class="col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
         <div class="{% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}">
             {% if classes.icon %}
-                <i class="material-icons prefix">{{ classes.icon }}</i>
+                {% include 'materializecssform/field_icon.html' %}
             {% endif %}
             <label>
                     {{ field }}
@@ -51,7 +51,7 @@
     {% elif field|is_date_input %}
     <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
         {% if classes.icon %}
-            <i class="material-icons prefix">{{ classes.icon }}</i>
+            {% include 'materializecssform/field_icon.html' %}
         {% endif %}
 
         <input type="date" id="{{ field.auto_id }}" name="{{ field.html_name }}" class="datepicker" value="{% if field.value %}{% localize off %}{{ field.value }}{% endlocalize %}{% endif %}" {% include 'materializecssform/attrs.html' %} >
@@ -71,7 +71,7 @@
     {% elif field|is_datetime_input %}
     <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
         {% if classes.icon %}
-            <i class="material-icons prefix">{{ classes.icon }}</i>
+            {% include 'materializecssform/field_icon.html' %}
         {% endif %}
 
         <input type="datetime-local" id="{{ field.auto_id }}" name="{{ field.html_name }}" value="{% if field.value %}{{ field.value|date:'c' }}{% endif %}" {% include 'materializecssform/attrs.html' %}  >
@@ -92,7 +92,7 @@
     <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
             {% if field|is_select_multiple %}
                 {% if classes.icon %}
-                    <i class="material-icons prefix">{{ classes.icon }}</i>
+                    {% include 'materializecssform/field_icon.html' %}
                 {% endif %}
                 <select multiple name="{{ field.html_name }}">
                     {% for choice in field %}
@@ -115,7 +115,7 @@
 
             {% else %}
                 {% if classes.icon %}
-                    <i class="material-icons prefix">{{ classes.icon }}</i>
+                    {% include 'materializecssform/field_icon.html' %}
                 {% endif %}
                 <select name="{{ field.html_name }}">
                     {% for choice in field %}
@@ -176,7 +176,7 @@
     {% elif field|is_textarea %}
         <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
             {% if classes.icon %}
-                <i class="material-icons prefix">{{ classes.icon }}</i>
+                {% include 'materializecssform/field_icon.html' %}
             {% endif %}
             <textarea id="{{ field.auto_id }}" class="materialize-textarea" name="{{field.html_name}}" {% include 'materializecssform/attrs.html' %} >{% if field.value %}{{ field.value }}{% endif %}</textarea>
             {% if field.auto_id %}
@@ -205,7 +205,7 @@
                 <div class="btn">
                     <span>{{ field.label }}</span>
                     {% if classes.icon %}
-                        <i class="material-icons prefix">{{ classes.icon }}</i>
+                        {% include 'materializecssform/field_icon.html' %}
                     {% endif %}
                     {{ field }}
                 </div>
@@ -219,7 +219,7 @@
 
         <div class="input-field col {{ classes.label }} {{ classes.value }} {{ classes.single_value }}">
             {% if classes.icon %}
-                <i class="material-icons prefix">{{ classes.icon }}</i>
+                {% include 'materializecssform/field_icon.html' %}
             {% endif %}
             {{ field }}
             {% if field.auto_id %}

--- a/materializecssform/templates/materializecssform/field_icon.html
+++ b/materializecssform/templates/materializecssform/field_icon.html
@@ -1,1 +1,7 @@
-<i class="material-icons prefix">{{ classes.icon }}</i>
+{% if icon_set == 'fontawesome' %}
+  <i class="{{ classes.icon }} prefix"></i>
+{% elif icon_set == 'glyphicon' %}
+  <span class="glyphicon {{ classes.icon }} prefix" aria-hidden="true"></span>
+{% else %}
+  <i class="material-icons prefix">{{ classes.icon }}</i>
+{% endif %}

--- a/materializecssform/templates/materializecssform/field_icon.html
+++ b/materializecssform/templates/materializecssform/field_icon.html
@@ -1,0 +1,1 @@
+<i class="material-icons prefix">{{ classes.icon }}</i>

--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -10,10 +10,11 @@ register = template.Library()
 
 @register.filter
 def materializecss(element, options={}):
-    if not options:
-        label_cols = 's12'
-        icon = ''
-    else:
+    # Set default values if none of them are set
+    label_cols = 's12'
+    icon = ''
+
+    if options:
         # Split options string into a list of arguments
         arguments = [arg.strip() for arg in options.split(',')]
 

--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -52,10 +52,13 @@ def add_input_classes(field):
 def render(element, markup_classes):
     element_type = element.__class__.__name__.lower()
 
+    # Get the icon set setting
+    icon_set = config.MATERIALIZECSS_ICON_SET
+
     if element_type == 'boundfield':
         add_input_classes(element)
         template = get_template("materializecssform/field.html")
-        context = {'field': element, 'classes': markup_classes}
+        context = {'field': element, 'classes': markup_classes, 'icon_set': icon_set}
     else:
         has_management = getattr(element, 'management_form', None)
         if has_management:
@@ -64,13 +67,13 @@ def render(element, markup_classes):
                     add_input_classes(field)
 
             template = get_template("materializecssform/formset.html")
-            context = {'formset': element, 'classes': markup_classes}
+            context = {'formset': element, 'classes': markup_classes, 'icon_set': icon_set}
         else:
             for field in element.visible_fields():
                 add_input_classes(field)
 
             template = get_template("materializecssform/form.html")
-            context = {'form': element, 'classes': markup_classes}
+            context = {'form': element, 'classes': markup_classes, 'icon_set': icon_set}
 
     return template.render(context)
 


### PR DESCRIPTION
Hello! I'm personally using Font Awesome instead of the built in icons for MaterializeCSS and refactored some of the code to support them.

I accidentally forgot to make this its own branch, don't really know if I can undo it in any good way.

## Summary modification

**Added support for optional icon sets, such as Font Awesome and GLYPHICONS.**

- Separated icon logic from the `field.html` template into its own `field_icon.html` file. If the support for optional icon sets is not wished merging only this addition is from commit https://github.com/kalwalkden/django-materializecss-form/commit/11f80f1ee801b66856b995257656b2bd081d18bc
- Added settings line `MATERIALIZECSS_ICON_SET` into `config.py`
- Added additional context variable `icon_set` in `materializecss.py` into the `render()` function. If more config based functionality is extended in the future this might be changed into a dict-like config variable instead.
- Updated documentation.

## Usage

Achievable by adding `MATERIALIZECSS_ICON_SET = 'fontawesome'` to the `settings.py` file and then using the icon as usual:

```html
{{ form.FIELD_NAME|materializecss:'s12 m6, icon=fas fa-user' }}
```