### PR TITLE
Handle classes for subwidgets in MultiWidget

### DIFF
--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -8,6 +8,7 @@ from materializecssform import config
 
 register = template.Library()
 
+
 @register.filter
 def materializecss(element, options={}):
     # Set default values if none of them are set
@@ -38,15 +39,14 @@ def materializecss(element, options={}):
     return render(element, markup_classes)
 
 
-
 def add_input_classes(field):
     if not is_checkbox(field) and not is_multiple_checkbox(field) and not is_radio(field) \
-        and not is_file(field):
+            and not is_file(field):
         field_classes = field.field.widget.attrs.get('class', '')
         if config.MATERIALIZECSS_VALIDATION:
             field_classes += ' validate'
         if field.errors:
-            field_classes+= ' invalid'
+            field_classes += ' invalid'
         field.field.widget.attrs['class'] = field_classes
 
 
@@ -83,6 +83,7 @@ def render(element, markup_classes):
 def is_checkbox(field):
     return isinstance(field.field.widget, forms.CheckboxInput)
 
+
 @register.filter
 def is_textarea(field):
     return isinstance(field.field.widget, forms.Textarea)
@@ -97,9 +98,11 @@ def is_multiple_checkbox(field):
 def is_radio(field):
     return isinstance(field.field.widget, forms.RadioSelect)
 
+
 @register.filter
 def is_date_input(field):
     return isinstance(field.field, DateField)
+
 
 @register.filter
 def is_datetime_input(field):

--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -122,3 +122,8 @@ def is_select(field):
 @register.filter
 def is_select_multiple(field):
     return isinstance(field.field.widget, forms.SelectMultiple)
+
+
+@register.filter
+def is_multi_widget(field):
+    return isinstance(field.field.widget, forms.MultiWidget)

--- a/materializecssform/templatetags/materializecss.py
+++ b/materializecssform/templatetags/materializecss.py
@@ -39,25 +39,22 @@ def materializecss(element, options={}):
     return render(element, markup_classes)
 
 
-def _add_input_classes_widget(widget, errors):
-    if not _is_checkbox_widget(widget) and not _is_multiple_checkbox_widget(widget) \
+def _add_input_classes_widget(widget, field_errors):
+    if _is_multi_widget(widget):
+        for subwidget in widget.widgets:
+            _add_input_classes_widget(subwidget, field_errors)
+    elif not _is_checkbox_widget(widget) and not _is_multiple_checkbox_widget(widget) \
             and not _is_radio_widget(widget) and not _is_file_widget(widget):
         classes = widget.attrs.get('class', '')
         if config.MATERIALIZECSS_VALIDATION:
             classes += ' validate'
-        if errors:
+        if field_errors:
             classes += ' invalid'
         widget.attrs['class'] = classes
 
 
 def add_input_classes(field):
-    if not is_checkbox(field) and not is_multiple_checkbox(field) and not is_radio(field) \
-            and not is_file(field):
-        if has_multi_widget(field):
-            for widget in field.field.widget.widgets:
-                _add_input_classes_widget(widget, field.errors)
-        else:
-            _add_input_classes_widget(field.field.widget, field.errors)
+    _add_input_classes_widget(field.field.widget, field.errors)
 
 
 def render(element, markup_classes):
@@ -105,6 +102,10 @@ def _is_file_widget(widget):
     return isinstance(widget, forms.FileInput)
 
 
+def _is_multi_widget(widget):
+    return isinstance(widget, forms.MultiWidget)
+
+
 @register.filter
 def is_checkbox(field):
     return isinstance(field.field.widget, forms.CheckboxInput)
@@ -148,8 +149,3 @@ def is_select(field):
 @register.filter
 def is_select_multiple(field):
     return isinstance(field.field.widget, forms.SelectMultiple)
-
-
-@register.filter
-def has_multi_widget(field):
-    return isinstance(field.field.widget, forms.MultiWidget)


### PR DESCRIPTION
Hi!

**issue**
In one of websites developed by me and my friends we use [SplitDateTimeField](https://docs.djangoproject.com/en/2.2/ref/forms/fields/#splitdatetimefield) with [SplitDateTimeWidget](https://docs.djangoproject.com/en/2.2/ref/forms/widgets/#django.forms.SplitDateTimeWidget). This widget is a subclass of MultiWidget. We add `datepicker` and `timepicker` classes in respective subwidgets of SplitDateTimeWidget via `attrs` attribute. Our problem was, that those classes hadn't been in fact added to rendered inputs.

I observed that function `add_input_classes` modifies `attrs` attribute of the widget associated with processed field. When this widget is subclassed from MultiWidget, then `attrs` from MultiWidget are modified and they override `attrs` in all of its subwidgets.

**solution**
This PR is an attempt to avoid classes modification on MultiWidgets by going recursively to subwidgets to perform modification there. It can handle nested MultiWidgets as well. Therefore subwidget's classes aren't overridden by MultiWidgets classes.

@kalwalkden feel free to review this PR and leave comments.

PS
I've got PEP8 autoformatting enabled, so there may also be some stylistic changes.