### PR TITLE
Fix package declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ import codecs
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 ###################################################################
 
 NAME = "django-materializecss-form"
-PACKAGES = find_packages(where="")
+PACKAGES = ["materializecssform"]
 META_PATH = os.path.join("materializecssform", "meta.py")
 KEYWORDS = ["materialize", "django", "css", "materializecss", "django forms"]
 CLASSIFIERS = [


### PR DESCRIPTION
There are a few points to list packages manually:

1. `find_packages` was used incorrectly that made it impossible to find the installed module in Python 3 #46 
2. For simple projects, it’s usually easy enough to manually add packages to the packages argument of `setup()` (see: https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages)