### PR TITLE
Use 'helper-text' spans on text inputs

### DIFF
--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -188,7 +188,7 @@
                 {% endfor %}
 
             {% if field.help_text %}
-                <p>
+                <p class="helper-text">
                     {{ field.help_text|safe }}
                 </p>
             {% endif %}
@@ -231,7 +231,7 @@
                 {% endfor %}
 
             {% if field.help_text %}
-                <p>
+                <p class="helper-text">
                     {{ field.help_text|safe }}
                 </p>
             {% endif %}

--- a/materializecssform/templates/materializecssform/field.html
+++ b/materializecssform/templates/materializecssform/field.html
@@ -188,9 +188,9 @@
                 {% endfor %}
 
             {% if field.help_text %}
-                <p class="helper-text">
+                <span class="helper-text">
                     {{ field.help_text|safe }}
-                </p>
+                </span>
             {% endif %}
         </div>
 
@@ -231,9 +231,9 @@
                 {% endfor %}
 
             {% if field.help_text %}
-                <p class="helper-text">
+                <span class="helper-text">
                     {{ field.help_text|safe }}
-                </p>
+                </span>
             {% endif %}
         </div>
 


### PR DESCRIPTION
According to the [Text Input documentation](https://materializecss.com/text-inputs.html), help texts have custom css through the 'helper-text' class. These help texts are span elements.